### PR TITLE
Add edit page button in reviews dashboard.

### DIFF
--- a/wagtail_review/templates/wagtail_review/admin/audit_trail.html
+++ b/wagtail_review/templates/wagtail_review/admin/audit_trail.html
@@ -51,6 +51,9 @@
                     <li>
                         <a class="button button-secondary button-small" href="{% url 'wagtail_review_admin:view_review_page' review_id=review.id %}">{% trans "View page" %}</a>
                     </li>
+                    <li>
+                        <a class="button button-secondary button-small" href="{% url 'wagtailadmin_pages:edit' review.page_revision.page.id %}">{% trans "Edit page" %}</a>
+                    </li>
                     {% if review.status == 'closed' %}
                         <li>
                             <form action="{% url 'wagtail_review_admin:reopen_review' review_id=review.id %}" method="POST">


### PR DESCRIPTION
A quick addition of an "Edit Page" button for the user to be able to access the admin edit of a page in review from the review dashboard.

Very handy and it has been raised a few times by some users 😄 

![Screenshot 2019-03-28 at 16 02 27](https://user-images.githubusercontent.com/10074977/55168493-37287d00-5173-11e9-824e-438a9aa42d08.png)

