### PR TITLE
"respond" review mode, review mode settings vars and README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,26 @@ Add a `{% wagtailreview %}` tag to your project's base template(s), towards the 
     {% wagtailreview %}
 
 
+## Review Modes
+
+There are three `review modes`:
+- `comment` mode (allowed to create annotations on a review)
+- `respond` mode (allowed to respond (annotate, comment and approve) a review)
+- `view` mode (allowed to only see a review and its annotations/comments - readonly)
+
+
+As is, this code has the following default `review modes` assigned:
+- _submitters_: `comment`
+- _reviewers_: `respond`
+- _users_: `view`
+
+This can be overriden with the following variables in your settings file:
+
+- `WAGTAIL_REVIEW_DEFAULT_SUBMITTER_MODE` for _submitters_
+- `WAGTAIL_REVIEW_DEFAULT_REVIEWER_MODE` for _reviewers_
+- `WAGTAIL_REVIEW_DEFAULT_USER_MODE` for _users_
+
+
 ## Custom notification emails
 
 To customise the notification email sent to reviewers, override the templates `wagtail_review/email/request_review_subject.txt` (for the subject line) and `wagtail_review/email/request_review.txt` (for the email content). This needs to be done in an app which appears above `wagtail_review` in the `INSTALLED_APPS` list.

--- a/wagtail_review/views/admin.py
+++ b/wagtail_review/views/admin.py
@@ -16,6 +16,8 @@ from wagtail.admin.views import generic
 from wagtail_review.forms import get_review_form_class, ReviewerFormSet
 from wagtail_review.models import Reviewer
 
+from django.conf import settings
+
 
 Review = swapper.load_model('wagtail_review', 'Review')
 User = get_user_model()
@@ -151,10 +153,21 @@ def view_review_page(request, review_id=None):
     dummy_request = page.dummy_request(request)
     dummy_request.wagtailreview_reviewer = reviewer
 
-    if reviewer.user == request.user:
-        dummy_request.wagtailreview_mode = 'comment'
+    if review.submitter == request.user:
+        dummy_request.wagtailreview_mode = getattr(
+            settings,
+            "WAGTAIL_REVIEW_DEFAULT_SUBMITTER_MODE",
+            "comment")
+    elif reviewer.user == request.user:
+        dummy_request.wagtailreview_mode = getattr(
+            settings,
+            "WAGTAIL_REVIEW_DEFAULT_REVIEWER_MODE",
+            "respond")
     else:
-        dummy_request.wagtailreview_mode = 'view'
+        dummy_request.wagtailreview_mode = getattr(
+            settings,
+            "WAGTAIL_REVIEW_DEFAULT_USER_MODE",
+            "view")
 
     return page.serve_preview(dummy_request, page.default_preview_mode)
 


### PR DESCRIPTION
Fixes #2 

As commented on issue #2 this would have a better behaviour out of the box.

By default:

- _submitters_ would have `comment` mode enabled
- _reviewers_ would have `respond` mode enabled
- _users_ would have `view` mode enabled

Settings variables to modify default behaviour have been enabled:

- `WAGTAIL_REVIEW_DEFAULT_SUBMITTER_MODE`
- `WAGTAIL_REVIEW_DEFAULT_REVIEWER_MODE`
- `WAGTAIL_REVIEW_DEFAULT_USER_MODE`

The README has been edited to explain this better.
I felt this was one of the issues I had when I first looked at the code and I thought the README changes could help better understand the functionality.
