### PR TITLE
Set CSRF token correctly on first request to 'respond' view

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -2,6 +2,7 @@
 ----------------
 
 * Logged-in users are now redirected back to the Wagtail admin after submitting a review (Maylon Pedroso)
+* Fix: CSRF token is now set correctly when the 'respond to review' view is the user's first request (Matt Westcott)
 
 
 0.1.1 (2018-10-17)


### PR DESCRIPTION
If a user visits the `views.frontend.respond` view without having previously visited a page that sets a CSRF cookie, the response fails to set a CSRF cookie, leading to 403 errors when submitting an annotation or response.

This is because Django sets a flag on the request object when the token is first accessed, telling the middleware to add a Set-Cookie header; in the case of the 'respond' view this happens in the dummy request, so the header never gets passed back to the user.

To fix this, we need to call `get_token` in the context of the real request, and then ensure the dummy request is using the same token (so that the right token appears in the output of the `{% wagtailreview %}` tag).