### PR TITLE
Create reviewer for user if none exists

### DIFF
--- a/wagtail_review/models.py
+++ b/wagtail_review/models.py
@@ -423,7 +423,7 @@ class ReviewTask(Task):
 
     def get_actions(self, page, user, reviewer=None, **kwargs):
         if not reviewer:
-            reviewer = Reviewer.objects.get_or_create(internal=user)[0]
+            reviewer, _ = Reviewer.objects.get_or_create(internal=user)
         if self.reviewers.filter(pk=reviewer.pk).exists() or user.is_superuser:
             return [
                 ('review', _("Review")),

--- a/wagtail_review/models.py
+++ b/wagtail_review/models.py
@@ -423,7 +423,7 @@ class ReviewTask(Task):
 
     def get_actions(self, page, user, reviewer=None, **kwargs):
         if not reviewer:
-            reviewer = Reviewer.objects.get(internal__pk=user.pk)
+            reviewer = Reviewer.objects.get_or_create(internal=user)[0]
         if self.reviewers.filter(pk=reviewer.pk).exists() or user.is_superuser:
             return [
                 ('review', _("Review")),


### PR DESCRIPTION
Create reviewer for user if none exists rather than trying to fetch a nonexistent reviewer. This fixes ReviewTask.get_actions when edit view is accessed by a user who does not have a Reviewer instance created