### PR TITLE
Prevent crash when checking permissions of external reviewer without shares

### DIFF
--- a/wagtail_review/models.py
+++ b/wagtail_review/models.py
@@ -187,7 +187,7 @@ class ReviewerPagePermissions:
         if not self.can_view():
             return False
 
-        if self.reviewer.external_id and not self.share.can_comment:
+        if self.reviewer.external_id and not (self.share and self.share.can_comment):
             # External users can leave comments without a share if they are a reviewer
             if self.can_review():
                 return True


### PR DESCRIPTION
Check for existence of share before checking share.can_comment to prevent exception for external reviewers without shares