### PR TITLE
Fix SubmitForReviewMenuItem for Wagtail 3.0

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -58,7 +58,7 @@ jobs:
             django: "Django>=4.0,<4.1"
             wagtail: "wagtail>=3.0,<3.1"
             database: "sqlite3"
-            experimental: true
+            experimental: false
           - python: "3.10"
             django: "Django>=4.1,<4.2"
             wagtail: "git+https://github.com/wagtail/wagtail.git@main#egg=wagtail"

--- a/wagtail_review/wagtail_hooks.py
+++ b/wagtail_review/wagtail_hooks.py
@@ -39,11 +39,11 @@ class SubmitForReviewMenuItem(ActionMenuItem):
     else:
         template = 'wagtail_review/submit_for_review_menu_item_pre_2_10.html'
 
-    def render_html(self, request, parent_context):
-        html = super().render_html(request, parent_context)
-        if WAGTAIL_VERSION < (2, 7):
+    if WAGTAIL_VERSION < (2, 7):
+        def render_html(self, request, parent_context):
+            html = super().render_html(request, parent_context)
             html = format_html('<li>{}</li>', html)
-        return html
+            return html
 
     class Media:
         js = ['wagtail_review/js/submit.js']


### PR DESCRIPTION
The signature of render_html changed in Wagtail 2.15. However, we only need to override it at all for the Wagtail <2.7 fallback code, so we can just extend the version check.