### PR TITLE
Fix missing icon in admin menu

### DIFF
--- a/wagtail_review/wagtail_hooks.py
+++ b/wagtail_review/wagtail_hooks.py
@@ -99,5 +99,5 @@ class ReviewsMenuItem(MenuItem):
 def register_images_menu_item():
     return ReviewsMenuItem(
         _('Reviews'), reverse('wagtail_review_admin:dashboard'),
-        name='reviews', classnames='icon icon-tick', order=1000
+        name='reviews', icon_name='tick-inverse', order=1000
     )


### PR DESCRIPTION
Not sure which version of wagtail changed the way to register an icon, but the icon is definitely missing when using version 6.3.

## Screenshots

(Taken on a local bakerydemo install)

<details>
<summary> Before (icon missing)</summary>

![Screenshot 2025-03-11 at 12-25-16 Editing Standard page About - Wagtail](https://github.com/user-attachments/assets/ac33fd06-c28a-4577-950e-03f998709d94)

</details>

<details>
<summary>After (icon fixed)</summary>

![Screenshot 2025-03-11 at 12-25-08 Editing Standard page About - Wagtail](https://github.com/user-attachments/assets/0e5f6ff6-b72a-4ba6-9778-6ea2135d6ef0)


</details>